### PR TITLE
Exclude KeyboardManager from extension targets and fix package warning.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
    targets: [
        .target(
            name: "InputBarAccessoryView",
-           path: "Sources"
+           path: "Sources",
+           exclude: ["Supporting Files/Info.plist"]
        )
    ],
    swiftLanguageVersions: [.v5]

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -28,6 +28,7 @@
 import UIKit
 
 /// An object that observes keyboard notifications such that event callbacks can be set for each notification
+@available(iOSApplicationExtension, unavailable)
 open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
     
     /// A callback that passes a `KeyboardNotification` as an input


### PR DESCRIPTION
This fixes swift-package related build errors on Xcode 13 where `KeyboardManager` would fail to build because it accesses `UIApplication.shared`.

This also fixes a warning where an unused `info.plist` was being imported.